### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/CycloBranch/core/cSequence.cpp
+++ b/CycloBranch/core/cSequence.cpp
@@ -204,7 +204,7 @@ string cSequence::getNameWithReferenceAsHTMLString() {
 		if (!correctreference) {
 			rx = "^DOI: ";
 			if (regex_search(reference, rx)) {
-				s += "<a href=\"http://dx.doi.org/" + reference.substr(5) + "\">";
+				s += "<a href=\"https://doi.org/" + reference.substr(5) + "\">";
 				s += name;
 				s += "</a>";
 				correctreference = true;

--- a/CycloBranch/gui/cAboutWidget.cpp
+++ b/CycloBranch/gui/cAboutWidget.cpp
@@ -21,17 +21,17 @@ cAboutWidget::cAboutWidget(QWidget* parent) {
 	QString citations = "Any work based on CycloBranch shall cite any of the following references:<br/><br/>";
 	citations += "Jiri Novak, Karel Lemr, Kevin A. Schug, Vladimir Havlicek:<br/>";
 	citations += "CycloBranch: <i>De Novo</i> Sequencing of Nonribosomal Peptides from Accurate Product Ion Mass Spectra,<br/>";
-	citations += "<i>J. Am. Soc. Mass Spectrom.</i>, vol. 26, no. 10, pp. 1780-1786, 2015. DOI: <a href=\"http://dx.doi.org/10.1007/s13361-015-1211-1\">10.1007/s13361-015-1211-1</a>.<br/>";
+	citations += "<i>J. Am. Soc. Mass Spectrom.</i>, vol. 26, no. 10, pp. 1780-1786, 2015. DOI: <a href=\"https://doi.org/10.1007/s13361-015-1211-1\">10.1007/s13361-015-1211-1</a>.<br/>";
 	citations += "Download citation: [ <a href=\"http://ms.biomed.cas.cz/cyclobranch/docs/cyclobranch_ris.txt\"><b>ris</b></a> ], [ <a href=\"http://ms.biomed.cas.cz/cyclobranch/docs/cyclobranch_bib.txt\"><b>bib</b></a> ]<br/><br/>";
 
 	citations += "Jiri Novak, Lucie Sokolova, Karel Lemr, Tomas Pluhacek, Andrea Palyzova, Vladimir Havlicek:<br/>";
 	citations += "Batch-processing of Imaging or Liquid-chromatography Mass Spectrometry Datasets and <i>De Novo</i> Sequencing of Polyketide Siderophores,<br/>";
-	citations += "<i>BBA - Proteins Proteom.</i>, vol. 1865, no. 7, pp. 768-775, 2017. DOI: <a href=\"http://dx.doi.org/10.1016/j.bbapap.2016.12.003\">10.1016/j.bbapap.2016.12.003</a>.<br/>";
+	citations += "<i>BBA - Proteins Proteom.</i>, vol. 1865, no. 7, pp. 768-775, 2017. DOI: <a href=\"https://doi.org/10.1016/j.bbapap.2016.12.003\">10.1016/j.bbapap.2016.12.003</a>.<br/>";
 	citations += "Download citation: [ <a href=\"http://ms.biomed.cas.cz/cyclobranch/docs/cyclobranch_bba_ris.txt\"><b>ris</b></a> ], [ <a href=\"http://ms.biomed.cas.cz/cyclobranch/docs/cyclobranch_bba_bib.txt\"><b>bib</b></a> ]<br/><br/>";
 
 	citations += "Jiri Novak, Anton Skriba, Jakub Zapal, Marek Kuzma, Vladimir Havlicek:<br/>";
 	citations += "CycloBranch: an Open Tool for Fine Isotope Structures in Conventional and Product Ion Mass Spectra,<br/>";
-	citations += "<i>J. Mass Spectrom.</i>, vol. 53, no. 11, pp. 1097-1103, 2018. DOI: <a href=\"http://dx.doi.org/10.1002/jms.4285\">10.1002/jms.4285</a>.<br/>";
+	citations += "<i>J. Mass Spectrom.</i>, vol. 53, no. 11, pp. 1097-1103, 2018. DOI: <a href=\"https://doi.org/10.1002/jms.4285\">10.1002/jms.4285</a>.<br/>";
 	citations += "Download citation: [ <a href=\"http://ms.biomed.cas.cz/cyclobranch/docs/cyclobranch_jms_ris.txt\"><b>ris</b></a> ], [ <a href=\"http://ms.biomed.cas.cz/cyclobranch/docs/cyclobranch_jms_bib.txt\"><b>bib</b></a> ]<br/><hr/><br/>";
 
 	QString licence = "Licence:<br/><br/> This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.<br/><br/>";

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ An open-source, cross-platform and stand-alone tool for mass spectrometry data a
 http://ms.biomed.cas.cz/cyclobranch/
   
 ## Publications
-  * [1] *J. Am. Soc. Mass Spectrom.* (2015), 26(10):1780-1786. DOI: [10.1007/s13361-015-1211-1](http://dx.doi.org/10.1007/s13361-015-1211-1)
-  * [2] *BBA - Proteins Proteom.* (2017), 1865(7):768-775. DOI: [10.1016/j.bbapap.2016.12.003](http://dx.doi.org/10.1016/j.bbapap.2016.12.003)
-  * [3] *Sci. Rep.* (2017), 7:16523. DOI: [10.1038/s41598-017-16648-z](http://dx.doi.org/10.1038/s41598-017-16648-z)
-  * [4] *J. Mass Spectrom.* (2018), 53(11):1097-1103. DOI: [10.1002/jms.4285](http://dx.doi.org/10.1002/jms.4285)
+  * [1] *J. Am. Soc. Mass Spectrom.* (2015), 26(10):1780-1786. DOI: [10.1007/s13361-015-1211-1](https://doi.org/10.1007/s13361-015-1211-1)
+  * [2] *BBA - Proteins Proteom.* (2017), 1865(7):768-775. DOI: [10.1016/j.bbapap.2016.12.003](https://doi.org/10.1016/j.bbapap.2016.12.003)
+  * [3] *Sci. Rep.* (2017), 7:16523. DOI: [10.1038/s41598-017-16648-z](https://doi.org/10.1038/s41598-017-16648-z)
+  * [4] *J. Mass Spectrom.* (2018), 53(11):1097-1103. DOI: [10.1002/jms.4285](https://doi.org/10.1002/jms.4285)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links and any code that generates new DOI links.

Cheers!